### PR TITLE
DTrace firing throws

### DIFF
--- a/lib/protocol/rpc_decoder.js
+++ b/lib/protocol/rpc_decoder.js
@@ -38,7 +38,7 @@ function RpcDecoder(options) {
                         _arguments: msg.data.d
                 }));
 
-                DTrace['rpc-start'].fire(function (p) {
+                DTrace.fire('rpc-start', function (p) {
                         return ([msg.data.m.name,
                                  msg.msgid,
                                  JSON.stringify(msg.data.d)]);

--- a/lib/protocol/rpc_encoder.js
+++ b/lib/protocol/rpc_encoder.js
@@ -43,7 +43,7 @@ RpcEncoder.prototype.end = function end() {
         this.status = proto.STATUS.END;
 
         process.nextTick(function () {
-                DTrace['rpc-done'].fire(function (p) {
+                DTrace.fire('rpc-done',function (p) {
                         return ([self.method, self.msgid]);
                 });
         });
@@ -83,8 +83,8 @@ RpcEncoder.prototype.encode = function encode() {
 
         msg._arguments = this._arguments;
         this.encoder.send(msg);
-
-        DTrace['rpc-msg'].fire(function (p) {
+        
+        DTrace.fire('rpc-msg', function (p) {
                 return ([self.method,
                         self.msgid,
                         self.status,


### PR DESCRIPTION
I assume you know what you're doing, so you can consider this pull request more as an illustrated question. Currently, I can not see how the dtrace firing can actually work with dtrace-provider 0.2.4 on a platform that does not support dtrace.

Anyway, I'm using this project on linux with this patch applied and since it follows the syntax in dtrace-provider's readme I don't see a reason that it should break other platforms.

Maybe you actually want to prevent it from working on a non dtrace enabled platform?
