### PR TITLE
Allow res.on('end', ...) in server.rpc()

### DIFF
--- a/lib/protocol/rpc_decoder.js
+++ b/lib/protocol/rpc_decoder.js
@@ -30,13 +30,18 @@ function RpcDecoder(options) {
 
                 var args = msg.data.d.slice();
                 args.unshift(msg.data.m.name);
-                args.push(new RpcEncoder({
+                var encoder = new RpcEncoder({
                         encoder: options.encoder,
                         method: msg.data.m.name,
                         msgid: msg.msgid,
                         start: msg.start,
                         _arguments: msg.data.d
-                }));
+                });
+                args.push(encoder);
+
+                decoder.once('end', function onEnd() {
+                        encoder.emit('end');
+                });
 
                 DTrace['rpc-start'].fire(function (p) {
                         return ([msg.data.m.name,

--- a/lib/protocol/rpc_encoder.js
+++ b/lib/protocol/rpc_encoder.js
@@ -35,6 +35,7 @@ function RpcEncoder(options) {
         // event on a server
         this._arguments = options._arguments;
 }
+util.inherits(RpcEncoder, EventEmitter);
 
 
 RpcEncoder.prototype.end = function end() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,6 +65,7 @@ function Server(options) {
                 });
 
                 conn.once('end', function onEnd() {
+                        messageDecoder.emit('end');
                         cleanup(conn, messageDecoder, messageEncoder);
                 });
 


### PR DESCRIPTION
This allows server.rpc() handlers to determine if the other end has disconnected.
