### PR TITLE
MORAY-324: client sometimes hang after a call to close()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -153,12 +153,34 @@ util.inherits(Client, EventEmitter);
 
 
 Client.prototype.close = function close() {
+    var self = this;
+
     this.closed = true;
     this.fast_reconnect = false;
     if (this.fast_conn) {
         this.fast_conn.destroy();
     } else {
-        // Stop any pending connection attempts
+        // Un-wire and destroy any pending connection
+        if (this._fast_pending_conn) {
+            this._fast_pending_conn.removeAllListeners();
+
+            // Swallow error events as we assume the user doesn't care about
+            // errors after calling close(), unless a custom error listener
+            // is set.
+            this._fast_pending_conn.on('error', function () {});
+
+            // Explicitly forward the 'close' event when the connection
+            // is pending, because if a pending connection is closed before
+            // being established, the code that handles that in _onConnection
+            // won't run.
+            this._fast_pending_conn.once('close', function onClose(had_err) {
+                self.emit('close', had_err);
+            });
+
+            this._fast_pending_conn.destroy();
+            this._fast_pending_conn = null;
+        }
+        // Stop looping for any pending connection attempts
         clearTimeout(this.fast_timer);
         if (this._fast_retry)
             this._fast_retry.abort();
@@ -200,11 +222,7 @@ Client.prototype._createSocket = function _createSocket(_, cb) {
     var self = this;
     var options = this._options;
     var callback = once(function (err, res) {
-        if (self.closed) {
-            // If the client is closed mid-connection, discard any results
-            return;
-        }
-        if (err) {
+        if (err && !self.closed) {
             self.emit('connectError', err);
         }
         cb(err, res);
@@ -228,6 +246,7 @@ Client.prototype._createSocket = function _createSocket(_, cb) {
             if (timer) {
                 clearTimeout(timer);
             }
+            self._fast_pending_conn = null;
             callback(err, res);
         }
 
@@ -240,6 +259,8 @@ Client.prototype._createSocket = function _createSocket(_, cb) {
             c.removeAllListeners('connect');
             done(err);
         });
+
+        self._fast_pending_conn = c;
     }
 
     if (IP_RE.test(options.host)) {
@@ -412,6 +433,9 @@ Client.prototype._nextMessageId = function _nextMessageId() {
 
 
 Client.prototype._onConnection = function _onConnection(connect_err, conn) {
+    assert.notEqual(this.closed, true,
+        'closed connection should run _onConnection callback');
+
     if (connect_err) {
         this.emit('error', connect_err);
         return;
@@ -439,6 +463,7 @@ Client.prototype._onConnection = function _onConnection(connect_err, conn) {
     });
 
     this.fast_conn = conn;
+
     this.fast_conn.setKeepAlive(true, 60000);
 
     this.messageDecoder = new protocol.MessageDecoder();

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -177,3 +177,83 @@ test('RPC error when not connected', function (t) {
         });
     });
 });
+
+// Regression test for https://smartos.org/bugview/MORAY-324.
+test('Close before connection established actually closes connection',
+    function (t) {
+        var client1EmittedClose = false;
+
+        server = fast.createServer();
+        server.listen(PORT, function () {
+            // Create a first client that we'll close right away.
+            // The goal is to reproduce the issue described by MORAY-324 where
+            // a client that would be immediately closed before establishing
+            // a connection would _not_ be closed, and would still connect
+            // to the server.
+            client = fast.createClient({
+                host: HOST,
+                port: PORT
+            });
+
+            client.close();
+
+            client.on('connect', function onClosedClientConnect() {
+                t.ok(false, 'closed client should not emit connect event');
+            });
+
+            client.on('close', function onClient1Close() {
+                client1EmittedClose = true;
+            });
+
+            // Create a second client, only for the purpose of making
+            // sure that the first one has the time to connect if the bug
+            // described in MORAY-324 is still present.
+            var client2 = fast.createClient({
+                host: HOST,
+                port: PORT
+            });
+
+            // Close the second client as soon as it connects so that it
+            // doesn't hold the libuv event loop open and allows the server
+            // to close (and thus the test to end) if the first client
+            // manages to close its connection.
+            client2.on('connect', function onClient2Connected() {
+                client2.close();
+            });
+
+            client2.on('close', function onClient2Closed() {
+                // When the second client closes, if the bug described by
+                // MORAY-324 is still present, the first client will have
+                // established a connection, and the server won't be able to
+                // close since the first client will never close.
+                // If MORAY-324 is fixed, the first client will have closed its
+                // connection before it's established, and thus as soon as the
+                // second client closes its connection, the server can close
+                // and the test can end.
+                server.close();
+
+                t.equal(client1EmittedClose, true, 'first client should ' +
+                    'have emitted close');
+
+                // Use a timeout to check for the number of current connections
+                // on the server, as when client2 closed its connection, the
+                // other end of the connection may not have closed yet.
+                // Delay of 1000ms is arbitrary, but should be enough to let
+                // the server side of the connection to close, and the
+                // net.Server's .connections property to be updated.
+                setTimeout(function waitForClientsClose() {
+                    server.srv.getConnections(function (err, nbConnections) {
+                        t.ifError(err, 'getConnections should not result in ' +
+                            'an error');
+                        t.equal(nbConnections, 0,
+                            'after second client closed, server should have ' +
+                            'no remaining client connected');
+                    });
+                }, 1000);
+            });
+        });
+
+        server.on('close', function onServerClosed() {
+            t.end();
+        });
+    });


### PR DESCRIPTION
Allows [`Client.prototype.close`](Client.prototype.close) to actually abort the connection if it hasn't been established yet. Otherwise, this can lead to the issue described at https://smartos.org/bugview/MORAY-324.

Note that the newly added test will make the process running the tests suite hang when running with the current implementation. A timeout could be added to make the test fail instead.

/cc @pfmooney