### PR TITLE
MORAY-326: node fast connection timeout not cleared on close

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -126,6 +126,7 @@ function Client(options) {
     var self = this;
     this.fast_msgid = 0;
     this.fast_conn = null;
+    this._fast_connect_timeout = null;
     this.fast_requests = {};
     this._pending_requests = 0;
     this._options = options;
@@ -155,6 +156,12 @@ util.inherits(Client, EventEmitter);
 Client.prototype.close = function close() {
     this.closed = true;
     this.fast_reconnect = false;
+
+    if (this._fast_connect_timeout) {
+        clearTimeout(this._fast_connect_timeout);
+        this._fast_connect_timeout = null;
+    }
+
     if (this.fast_conn) {
         this.fast_conn.destroy();
     } else {
@@ -217,11 +224,10 @@ Client.prototype._createSocket = function _createSocket(_, cb) {
 
     function _socket() {
         var c = net.connect(options);
-        var timer = null;
         var to = options.connectTimeout;
 
         if (options.connectTimeout > 0) {
-            timer = setTimeout(function () {
+            self._fast_connect_timeout = setTimeout(function () {
                 c.removeAllListeners('connect');
                 c.removeAllListeners('error');
                 c.destroy();
@@ -230,8 +236,9 @@ Client.prototype._createSocket = function _createSocket(_, cb) {
         }
 
         function done(err, res) {
-            if (timer) {
-                clearTimeout(timer);
+            if (self._fast_connect_timeout) {
+                clearTimeout(self._fast_connect_timeout);
+                self._fast_connect_timeout = null;
             }
             self._fast_pending_conn = null;
             callback(err, res);


### PR DESCRIPTION
Fixes [MORAY-326](https://smartos.org/bugview/MORAY-326).

The newly added test currently uses `process._getActiveHandles()`, which is far from ideal. The only other way to test that I could think of was to add an option to `createClient` to _not_ suppress errors on close and check that the `'connectError'` event is not emitted.

The previous test `'socket properly hangs up via close'` was updated so that it would end when the timeout's callback runs, so that no active handle is left and `process._getActiveHandles` can be used in the newly added test.