### PR TITLE
CNAPI-648: cnapi aborting on AssertionError: connection state change after close

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -193,7 +193,14 @@ Client.prototype.connect = function connect() {
     var opts = this._options;
     var retry = backoff.call(this._createSocket.bind(this), {},
     function (err, conn) {
-        self._onConnection(err, conn);
+        // Starting with backoff 2.5.0, the backoff callback is called when the
+        // backoff instance is aborted. In this case, the _onConnection callback
+        // should not be called, since its purpose is to handle the result of
+        // the bind call that is being backed off, not events in the backoff
+        // process itself.
+        if (!retry.isAborted()) {
+            self._onConnection(err, conn);
+        }
     });
 
     retry.on('backoff', this.emit.bind(this, 'connectAttempt'));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "name": "fast",
     "homepage": "https://github.com/mcavage/node-fast",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "assert-plus": "^0.1.5",
-        "backoff": "^2.4.1",
+        "backoff": "~2.5.0",
         "crc": "^0.3.0",
         "microtime": "^2.0.0",
         "once": "^1.3.2",

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -281,3 +281,19 @@ test('client timeout should be cleared on close', function (t) {
             });
         });
     });
+
+// This is essentially a regression test for
+// https://smartos.org/bugview/CNAPI-648.
+test('close does not assert', function (t) {
+    // Arguments passed to createClient below are set just to that the client
+    // creation does not assert. The port and connectTimeout arguments do not
+    // have a specific purpose, since the test closes the client before it had a
+    // chance to establish any connection anyway.
+    client = fast.createClient({
+        port: PORT,
+        connectTimeout: TIMEOUT_MS
+    });
+
+    client.close();
+    t.end();
+});


### PR DESCRIPTION
This is a fix for https://smartos.org/bugview/CNAPI-648. I'm wondering if node-fast could also pin down its dependencies a bit more strictly, using semver `~` (flexible patch version) instead of semver `^` (flexible patch _and_ minor versions).
